### PR TITLE
Add stubs required by imageio

### DIFF
--- a/stubs/hosts/2900d577-63a8-4ec9-acff-8493278346b1/content.json
+++ b/stubs/hosts/2900d577-63a8-4ec9-acff-8493278346b1/content.json
@@ -1,0 +1,235 @@
+{
+  "host" : {
+    "address" : "rhv.example.com",
+    "auto_numa_status" : "unknown",
+    "certificate" : {
+      "organization" : "example.com",
+      "subject" : "O=example.com,CN=example.com"
+    },
+    "cpu" : {
+      "name" : "Westmere E56xx/L56xx/X56xx (Nehalem-C)",
+      "speed" : 2200,
+      "topology" : {
+        "cores" : "1",
+        "sockets" : "4",
+        "threads" : "1"
+      },
+      "type" : "Intel Westmere Family"
+    },
+    "device_passthrough" : {
+      "enabled" : "false"
+    },
+    "external_status" : "ok",
+    "hardware_information" : {
+      "family" : "Red Hat Enterprise Linux",
+      "manufacturer" : "Red Hat",
+      "product_name" : "RHEV Hypervisor",
+      "serial_number" : "4c4c4544-0038-3710-8059-b6c04f4d3632",
+      "supported_rng_sources" : {
+        "supported_rng_source" : [ "hwrng", "random" ]
+      },
+      "uuid" : "8C222E80-6933-4E28-8F15-9B3BCC99C50A",
+      "version" : "7.9-6.el7_9"
+    },
+    "iscsi" : {
+      "initiator" : "iqn.1994-05.com.redhat:c68a9c47e1cb"
+    },
+    "kdump_status" : "disabled",
+    "ksm" : {
+      "enabled" : "false"
+    },
+    "libvirt_version" : {
+      "build" : "0",
+      "full_version" : "libvirt-8.0.0-2.module_el8.6.0+1087+b42c8331",
+      "major" : "8",
+      "minor" : "0",
+      "revision" : "0"
+    },
+    "max_scheduling_memory" : "3505389568",
+    "memory" : "3910139904",
+    "numa_supported" : "false",
+    "os" : {
+      "custom_kernel_cmdline" : "",
+      "reported_kernel_cmdline" : "BOOT_IMAGE=(hd0,msdos1)/vmlinuz-4.18.0-358.el8.x86_64 root=/dev/mapper/cs_10--37--140--134-root ro crashkernel=auto resume=/dev/mapper/cs_10--37--140--134-swap rd.lvm.lv=cs_10-37-140-134/root rd.lvm.lv=cs_10-37-140-134/swap rhgb quiet",
+      "type" : "RHEL",
+      "version" : {
+        "full_version" : "8.6 - 1.el8",
+        "major" : "8",
+        "minor" : "6"
+      }
+    },
+    "port" : "54321",
+    "power_management" : {
+      "automatic_pm_enabled" : "true",
+      "enabled" : "false",
+      "kdump_detection" : "true",
+      "pm_proxies" : { }
+    },
+    "protocol" : "stomp",
+    "reinstallation_required" : "false",
+    "se_linux" : {
+      "mode" : "enforcing"
+    },
+    "spm" : {
+      "priority" : "5",
+      "status" : "spm"
+    },
+    "ssh" : {
+      "fingerprint" : "SHA256:gwnUee4QbRl85LI3StDaCGtPdfF4+BendzJTyQYTs+I",
+      "port" : "22",
+      "public_key" : "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHIDgsxyz8SRyUTVf3SVizVlTZm9uQwboBBtrFlQaBd29LPl686+GPR89PwiOCqi0IDFGN06vSbOwLJswYqEOzM="
+    },
+    "status" : "up",
+    "summary" : {
+      "active" : "0",
+      "migrating" : "0",
+      "total" : "0"
+    },
+    "transparent_hugepages" : {
+      "enabled" : "true"
+    },
+    "type" : "rhel",
+    "update_available" : "true",
+    "version" : {
+      "build" : "100",
+      "full_version" : "vdsm-4.40.100.2-1.el8",
+      "major" : "4",
+      "minor" : "40",
+      "revision" : "2"
+    },
+    "vgpu_placement" : "consolidated",
+    "cluster" : {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e",
+      "id" : "b94f0a35-8ed8-429c-999a-4d776640107e"
+    },
+    "network_attachments" : {
+      "network_attachment" : [ {
+        "in_sync" : "true",
+        "ip_address_assignments" : {
+          "ip_address_assignment" : [ {
+            "assignment_method" : "dhcp",
+            "ip" : {
+              "version" : "v4"
+            }
+          }, {
+            "assignment_method" : "poly_dhcp_autoconf",
+            "ip" : {
+              "version" : "v6"
+            }
+          } ]
+        },
+        "reported_configurations" : {
+          "reported_configuration" : [ {
+            "actual_value" : "1500",
+            "expected_value" : "1500",
+            "in_sync" : "true",
+            "name" : "mtu"
+          }, {
+            "actual_value" : "true",
+            "expected_value" : "true",
+            "in_sync" : "true",
+            "name" : "bridged"
+          }, {
+            "in_sync" : "true",
+            "name" : "vlan"
+          }, {
+            "actual_value" : "LEGACY",
+            "expected_value" : "LEGACY",
+            "in_sync" : "true",
+            "name" : "switchType"
+          }, {
+            "actual_value" : "DHCP",
+            "expected_value" : "DHCP",
+            "in_sync" : "true",
+            "name" : "ipv4_boot_protocol"
+          }, {
+            "actual_value" : "POLY_DHCP_AUTOCONF",
+            "expected_value" : "POLY_DHCP_AUTOCONF",
+            "in_sync" : "true",
+            "name" : "ipv6_boot_protocol"
+          }, {
+            "actual_value" : "10.37.136.1,10.37.136.3",
+            "in_sync" : "true",
+            "name" : "dns_configuration"
+          }, {
+            "actual_value" : "true",
+            "expected_value" : "true",
+            "in_sync" : "true",
+            "name" : "default_route"
+          } ]
+        },
+        "host" : {
+          "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1",
+          "id" : "2900d577-63a8-4ec9-acff-8493278346b1"
+        },
+        "host_nic" : {
+          "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5",
+          "id" : "78a019f2-262d-479d-93b8-cf17fce112a5"
+        },
+        "network" : {
+          "href" : "/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89",
+          "id" : "6b6b7239-5ea1-4f08-a76e-be150ab8eb89"
+        },
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/networkattachments/fc7e3867-24fd-4f9c-ad6b-17c65202886f",
+        "id" : "fc7e3867-24fd-4f9c-ad6b-17c65202886f"
+      } ]
+    },
+    "nics" : {
+      "host_nic" : [ {
+        "boot_protocol" : "dhcp",
+        "bridged" : "true",
+        "custom_configuration" : "false",
+        "ip" : {
+          "address" : "10.37.140.134",
+          "gateway" : "10.37.143.254",
+          "netmask" : "255.255.248.0",
+          "version" : "v4"
+        },
+        "ipv6" : {
+          "address" : "2620:52:0:2588:21a:4aff:fe01:3f52",
+          "gateway" : "::",
+          "netmask" : "64",
+          "version" : "v6"
+        },
+        "ipv6_boot_protocol" : "poly_dhcp_autoconf",
+        "mac" : {
+          "address" : "00:1a:4a:01:3f:52"
+        },
+        "mtu" : "1500",
+        "properties" : { },
+        "status" : "up",
+        "host" : {
+          "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1",
+          "id" : "2900d577-63a8-4ec9-acff-8493278346b1"
+        },
+        "network" : {
+          "href" : "/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89",
+          "id" : "6b6b7239-5ea1-4f08-a76e-be150ab8eb89"
+        },
+        "actions" : {
+          "link" : [ ]
+        },
+        "name" : "ens3",
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5",
+        "id" : "78a019f2-262d-479d-93b8-cf17fce112a5",
+        "link" : [ {
+          "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/linklayerdiscoveryprotocolelements",
+          "rel" : "linklayerdiscoveryprotocolelements"
+        }, {
+          "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/networklabels",
+          "rel" : "networklabels"
+        }, {
+          "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/networkattachments",
+          "rel" : "networkattachments"
+        }, {
+          "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/statistics",
+          "rel" : "statistics"
+        } ]
+      } ]
+    },
+    "name" : "vhost",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1",
+    "id" : "2900d577-63a8-4ec9-acff-8493278346b1",
+  }
+}

--- a/stubs/hosts/2900d577-63a8-4ec9-acff-8493278346b1/content.xml
+++ b/stubs/hosts/2900d577-63a8-4ec9-acff-8493278346b1/content.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<host href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1" id="2900d577-63a8-4ec9-acff-8493278346b1">
+  <name>vhost</name>
+  <comment/>
+  <address>example.com</address>
+  <auto_numa_status>unknown</auto_numa_status>
+  <certificate>
+    <organization>example.com</organization>
+    <subject>O=example.com,CN=example.com</subject>
+  </certificate>
+  <cpu>
+    <name>Westmere E56xx/L56xx/X56xx (Nehalem-C)</name>
+    <speed>2200</speed>
+    <topology>
+      <cores>1</cores>
+      <sockets>4</sockets>
+      <threads>1</threads>
+    </topology>
+    <type>Intel Westmere Family</type>
+  </cpu>
+  <device_passthrough>
+    <enabled>false</enabled>
+  </device_passthrough>
+  <external_status>ok</external_status>
+  <hardware_information>
+    <family>Red Hat Enterprise Linux</family>
+    <manufacturer>Red Hat</manufacturer>
+    <product_name>RHEV Hypervisor</product_name>
+    <serial_number>4c4c4544-0038-3710-8059-b6c04f4d3632</serial_number>
+    <supported_rng_sources>
+      <supported_rng_source>hwrng</supported_rng_source>
+      <supported_rng_source>random</supported_rng_source>
+    </supported_rng_sources>
+    <uuid>8C222E80-6933-4E28-8F15-9B3BCC99C50A</uuid>
+    <version>7.9-6.el7_9</version>
+  </hardware_information>
+  <iscsi>
+    <initiator>iqn.1994-05.com.redhat:c68a9c47e1cb</initiator>
+  </iscsi>
+  <kdump_status>disabled</kdump_status>
+  <ksm>
+    <enabled>false</enabled>
+  </ksm>
+  <libvirt_version>
+    <build>0</build>
+    <full_version>libvirt-8.0.0-2.module_el8.6.0+1087+b42c8331</full_version>
+    <major>8</major>
+    <minor>0</minor>
+    <revision>0</revision>
+  </libvirt_version>
+  <max_scheduling_memory>3505389568</max_scheduling_memory>
+  <memory>3910139904</memory>
+  <numa_supported>false</numa_supported>
+  <os>
+    <custom_kernel_cmdline/>
+    <reported_kernel_cmdline>BOOT_IMAGE=(hd0,msdos1)/vmlinuz-4.18.0-358.el8.x86_64 root=/dev/mapper/cs_10--37--140--134-root ro crashkernel=auto resume=/dev/mapper/cs_10--37--140--134-swap rd.lvm.lv=cs_10-37-140-134/root rd.lvm.lv=cs_10-37-140-134/swap rhgb quiet</reported_kernel_cmdline>
+    <type>RHEL</type>
+    <version>
+      <full_version>8.6 - 1.el8</full_version>
+      <major>8</major>
+      <minor>6</minor>
+    </version>
+  </os>
+  <port>54321</port>
+  <power_management>
+    <automatic_pm_enabled>true</automatic_pm_enabled>
+    <enabled>false</enabled>
+    <kdump_detection>true</kdump_detection>
+    <pm_proxies/>
+  </power_management>
+  <protocol>stomp</protocol>
+  <reinstallation_required>false</reinstallation_required>
+  <se_linux>
+    <mode>enforcing</mode>
+  </se_linux>
+  <spm>
+    <priority>5</priority>
+    <status>spm</status>
+  </spm>
+  <ssh>
+    <fingerprint>SHA256:gwnUee4QbRl85LI3StDaCGtPdfF4+BendzJTyQYTs+I</fingerprint>
+    <port>22</port>
+    <public_key>ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHIDgsxyz8SRyUTVf3SVizVlTZm9uQwboBBtrFlQaBd29LPl686+GPR89PwiOCqi0IDFGN06vSbOwLJswYqEOzM=</public_key>
+  </ssh>
+  <status>up</status>
+  <summary>
+    <active>0</active>
+    <migrating>0</migrating>
+    <total>0</total>
+  </summary>
+  <transparent_hugepages>
+    <enabled>true</enabled>
+  </transparent_hugepages>
+  <type>rhel</type>
+  <update_available>true</update_available>
+  <version>
+    <build>100</build>
+    <full_version>vdsm-4.40.100.2-1.el8</full_version>
+    <major>4</major>
+    <minor>40</minor>
+    <revision>2</revision>
+  </version>
+  <vgpu_placement>consolidated</vgpu_placement>
+  <cluster href="/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e" id="b94f0a35-8ed8-429c-999a-4d776640107e"/>
+  <network_attachments>
+    <network_attachment href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/networkattachments/fc7e3867-24fd-4f9c-ad6b-17c65202886f" id="fc7e3867-24fd-4f9c-ad6b-17c65202886f">
+      <in_sync>true</in_sync>
+      <ip_address_assignments>
+        <ip_address_assignment>
+          <assignment_method>dhcp</assignment_method>
+          <ip>
+            <version>v4</version>
+          </ip>
+        </ip_address_assignment>
+        <ip_address_assignment>
+          <assignment_method>poly_dhcp_autoconf</assignment_method>
+          <ip>
+            <version>v6</version>
+          </ip>
+        </ip_address_assignment>
+      </ip_address_assignments>
+      <reported_configurations>
+        <reported_configuration>
+          <actual_value>1500</actual_value>
+          <expected_value>1500</expected_value>
+          <in_sync>true</in_sync>
+          <name>mtu</name>
+        </reported_configuration>
+        <reported_configuration>
+          <actual_value>true</actual_value>
+          <expected_value>true</expected_value>
+          <in_sync>true</in_sync>
+          <name>bridged</name>
+        </reported_configuration>
+        <reported_configuration>
+          <in_sync>true</in_sync>
+          <name>vlan</name>
+        </reported_configuration>
+        <reported_configuration>
+          <actual_value>LEGACY</actual_value>
+          <expected_value>LEGACY</expected_value>
+          <in_sync>true</in_sync>
+          <name>switchType</name>
+        </reported_configuration>
+        <reported_configuration>
+          <actual_value>DHCP</actual_value>
+          <expected_value>DHCP</expected_value>
+          <in_sync>true</in_sync>
+          <name>ipv4_boot_protocol</name>
+        </reported_configuration>
+        <reported_configuration>
+          <actual_value>POLY_DHCP_AUTOCONF</actual_value>
+          <expected_value>POLY_DHCP_AUTOCONF</expected_value>
+          <in_sync>true</in_sync>
+          <name>ipv6_boot_protocol</name>
+        </reported_configuration>
+        <reported_configuration>
+          <actual_value>10.37.136.1,10.37.136.3</actual_value>
+          <in_sync>true</in_sync>
+          <name>dns_configuration</name>
+        </reported_configuration>
+        <reported_configuration>
+          <actual_value>true</actual_value>
+          <expected_value>true</expected_value>
+          <in_sync>true</in_sync>
+          <name>default_route</name>
+        </reported_configuration>
+      </reported_configurations>
+      <host href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1" id="2900d577-63a8-4ec9-acff-8493278346b1"/>
+      <host_nic href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5" id="78a019f2-262d-479d-93b8-cf17fce112a5"/>
+      <network href="/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89" id="6b6b7239-5ea1-4f08-a76e-be150ab8eb89"/>
+    </network_attachment>
+  </network_attachments>
+  <nics>
+    <host_nic href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5" id="78a019f2-262d-479d-93b8-cf17fce112a5">
+      <actions/>
+      <name>ens3</name>
+      <link href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/linklayerdiscoveryprotocolelements" rel="linklayerdiscoveryprotocolelements"/>
+      <link href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/networklabels" rel="networklabels"/>
+      <link href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/networkattachments" rel="networkattachments"/>
+      <link href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics/78a019f2-262d-479d-93b8-cf17fce112a5/statistics" rel="statistics"/>
+      <boot_protocol>dhcp</boot_protocol>
+      <bridged>true</bridged>
+      <custom_configuration>false</custom_configuration>
+      <ip>
+        <address>10.37.140.134</address>
+        <gateway>10.37.143.254</gateway>
+        <netmask>255.255.248.0</netmask>
+        <version>v4</version>
+      </ip>
+      <ipv6>
+        <address>2620:52:0:2588:21a:4aff:fe01:3f52</address>
+        <gateway>::</gateway>
+        <netmask>64</netmask>
+        <version>v6</version>
+      </ipv6>
+      <ipv6_boot_protocol>poly_dhcp_autoconf</ipv6_boot_protocol>
+      <mac>
+        <address>00:1a:4a:01:3f:52</address>
+      </mac>
+      <mtu>1500</mtu>
+      <properties/>
+      <status>up</status>
+      <host href="/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1" id="2900d577-63a8-4ec9-acff-8493278346b1"/>
+      <network href="/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89" id="6b6b7239-5ea1-4f08-a76e-be150ab8eb89"/>
+    </host_nic>
+  </nics>
+</host>
+

--- a/stubs/imagetransfers/stub.json
+++ b/stubs/imagetransfers/stub.json
@@ -4,8 +4,9 @@
     "method": "POST",
     "responses": [
       {
+	"responseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><action><status>complete</status></action>",
         "responseCode": 200,
-        "times": 3
+	"times": 10000
       }
     ]
   },
@@ -15,40 +16,45 @@
     "responses": [
       {
         "responseCode": 200,
+	"times": 10000
+      }
+    ]
+  },
+  {
+    "path": "/ovirt-engine/api/imagetransfers/abc123",
+    "method": "POST",
+    "responses": [
+      {
+        "responseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>transferring</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url></image_transfer>",
+        "responseCode": 200,
+	"times": 10000
+      }
+    ]
+  },
+  {
+    "path": "/ovirt-engine/api/imagetransfers",
+    "method": "POST",
+    "responses": [
+      {
+        "responseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>transferring</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url></image_transfer>",
+        "responseCode": 201,
+	"times": 10000
+      }
+    ]
+  },
+  {
+    "path": "/ovirt-engine/api/imagetransfers/abc123",
+    "method": "GET",
+    "responses": [
+      {
+        "responseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>transferring</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url><host href=\"/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1\" id=\"2900d577-63a8-4ec9-acff-8493278346b1\"/></image_transfer>",
+        "responseCode": 200,
         "times": 3
-      }
-    ]
-  },
-  {
-    "path": "/ovirt-engine/api/imagetransfers/abc123",
-    "method": "POST",
-    "responses": [
+      },
       {
-        "responseBody": "<image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>transferring</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url></image_transfer>",
+        "responseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>finished_success</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url><host href=\"/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1\" id=\"2900d577-63a8-4ec9-acff-8493278346b1\"/></image_transfer>",
         "responseCode": 200,
-        "times": 1
-      }
-    ]
-  },
-  {
-    "path": "/ovirt-engine/api/imagetransfers",
-    "method": "POST",
-    "responses": [
-      {
-        "responseBody": "<image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>transferring</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url></image_transfer>",
-        "responseCode": 200,
-        "times": 1
-      }
-    ]
-  },
-  {
-    "path": "/ovirt-engine/api/imagetransfers/abc123",
-    "method": "GET",
-    "responses": [
-      {
-        "responseBody": "<image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>finalizing_success</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url></image_transfer>",
-        "responseCode": 200,
-        "times": 1
+	"times": 10000
       }
     ]
   },
@@ -57,9 +63,9 @@
     "method": "GET",
     "responses": [
       {
-        "responseBody": "<image_transfers><image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>finalizing_success</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url></image_transfer><image_transfers>",
+        "responseBody": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><image_transfers><image_transfer href=\"/ovirt-engine/api/imagetransfers/abc123\" id=\"abc123\"><direction>download</direction><format>raw</format><phase>finalizing_success</phase><transfer_url>http://ovirt-imageio.konveyor-forklift:12345/images/cirros</transfer_url></image_transfer><image_transfers>",
         "responseCode": 200,
-        "times": 10
+	"times": 10000
       }
     ]
   }

--- a/stubs/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/content.json
+++ b/stubs/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/content.json
@@ -1,0 +1,32 @@
+{
+  "storage_domain": {
+    "name": "test",
+    "description": "",
+    "comment": "",
+    "available": 7516192768,
+    "backup": false,
+    "block_size": 512,
+    "committed": 11811160064,
+    "critical_space_action_blocker": 5,
+    "discard_after_delete": false,
+    "external_status": "ok",
+    "master": true,
+    "storage": {
+      "address": "rhv.example.com",
+      "nfs_timeo": 200,
+      "nfs_version": "v4",
+      "path": "/exports/data",
+      "type": "nfs"
+    },
+    "storage_format": "v5",
+    "supports_discard": false,
+    "supports_discard_zeroes_data": false,
+    "type": "data",
+    "used": 9663676416,
+    "warning_low_space_indicator": 10,
+    "wipe_after_delete": false,
+    "data_centers": {
+      "data_center": ""
+    }
+  }
+}

--- a/stubs/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/content.xml
+++ b/stubs/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/content.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<storage_domain href="/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8" id="95ef6fee-5773-46a2-9340-a636958a96b8">
+    <name>test</name>
+    <description></description>
+    <comment></comment>
+    <available>7516192768</available>
+    <backup>false</backup>
+    <block_size>512</block_size>
+    <committed>11811160064</committed>
+    <critical_space_action_blocker>5</critical_space_action_blocker>
+    <discard_after_delete>false</discard_after_delete>
+    <external_status>ok</external_status>
+    <master>true</master>
+    <storage>
+	<address>rhv.example.com</address>
+        <nfs_timeo>200</nfs_timeo>
+        <nfs_version>v4</nfs_version>
+        <path>/exports/data</path>
+        <type>nfs</type>
+    </storage>
+    <storage_format>v5</storage_format>
+    <supports_discard>false</supports_discard>
+    <supports_discard_zeroes_data>false</supports_discard_zeroes_data>
+    <type>data</type>
+    <used>9663676416</used>
+    <warning_low_space_indicator>10</warning_low_space_indicator>
+    <wipe_after_delete>false</wipe_after_delete>
+    <data_centers>
+        <data_center href="/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878" id="32ebd239-25a2-4a13-b514-5bf7c8de6878"/>
+    </data_centers>
+</storage_domain>


### PR DESCRIPTION
When importing with the populator it uses ovirt-imageio client. The client requires more stubs and some changes in the imagetransfer ones.